### PR TITLE
replace https with http on imgur urls

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,7 +2,7 @@ var reloadCount = 0;
 
 // Redirect imgur.com requests to Duckduckgo proxy
 chrome.webRequest.onBeforeRequest.addListener(function (details) {
-    var redirectUrl = "https://proxy.duckduckgo.com/iu/?u=" + details.url.replace(https, http);
+    var redirectUrl = "https://proxy.duckduckgo.com/iu/?u=" + details.url.replace("https://", "http://");
     redirectUrl = redirectUrl.replace(/ref=.*&|ref=.*$/, "");
     return {redirectUrl: redirectUrl};
 }, {

--- a/background.js
+++ b/background.js
@@ -2,7 +2,7 @@ var reloadCount = 0;
 
 // Redirect imgur.com requests to Duckduckgo proxy
 chrome.webRequest.onBeforeRequest.addListener(function (details) {
-    var redirectUrl = "https://proxy.duckduckgo.com/iu/?u=" + details.url;
+    var redirectUrl = "https://proxy.duckduckgo.com/iu/?u=" + details.url.replace(https, http);
     redirectUrl = redirectUrl.replace(/ref=.*&|ref=.*$/, "");
     return {redirectUrl: redirectUrl};
 }, {


### PR DESCRIPTION
'https' addresses don't work for me, but manually replacing 'https' to 'http' works. So this should fix the problem by automatically replacing them.

Please note that I haven't tested this since I don't have much experience with chrome extensions. So you might want to test it out before merging.